### PR TITLE
Fix missing templates/, etc in setuptools install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,97 @@
-
 from setuptools import setup, find_packages
+from distutils.util import convert_path
+import os
+from fnmatch import fnmatchcase
 
 from gnotty import __version__, __url__
+
+# Provided as an attribute, so you can append to these instead
+# of replicating them:
+standard_exclude = ('*.py', '*.pyc', '*$py.class', '*~', '.*', '*.bak')
+standard_exclude_directories = ('.*', 'CVS', '_darcs', './build',
+                                './dist', 'EGG-INFO', '*.egg-info')
+
+# (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
+# Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
+# Note: you may want to copy this into your setup.py file verbatim, as
+# you can't import this from another package, when you don't know if
+# that package is installed yet.
+def find_package_data(
+    where='.', package='',
+    exclude=standard_exclude,
+    exclude_directories=standard_exclude_directories,
+    only_in_packages=True,
+    show_ignored=False):
+    """
+    Return a dictionary suitable for use in ``package_data``
+    in a distutils ``setup.py`` file.
+
+    The dictionary looks like::
+
+        {'package': [files]}
+
+    Where ``files`` is a list of all the files in that package that
+    don't match anything in ``exclude``.
+
+    If ``only_in_packages`` is true, then top-level directories that
+    are not packages won't be included (but directories under packages
+    will).
+
+    Directories matching any pattern in ``exclude_directories`` will
+    be ignored; by default directories with leading ``.``, ``CVS``,
+    and ``_darcs`` will be ignored.
+
+    If ``show_ignored`` is true, then all the files that aren't
+    included in package data are shown on stderr (for debugging
+    purposes).
+
+    Note patterns use wildcards, or can be exact paths (including
+    leading ``./``), and all searching is case-insensitive.
+    """
+    out = {}
+    stack = [(convert_path(where), '', package, only_in_packages)]
+    while stack:
+        where, prefix, package, only_in_packages = stack.pop(0)
+        for name in os.listdir(where):
+            fn = os.path.join(where, name)
+            if os.path.isdir(fn):
+                bad_name = False
+                for pattern in exclude_directories:
+                    if (fnmatchcase(name, pattern)
+                        or fn.lower() == pattern.lower()):
+                        bad_name = True
+                        if show_ignored:
+                            print >> sys.stderr, (
+                                "Directory %s ignored by pattern %s"
+                                % (fn, pattern))
+                        break
+                if bad_name:
+                    continue
+                if (os.path.isfile(os.path.join(fn, '__init__.py'))
+                    and not prefix):
+                    if not package:
+                        new_package = name
+                    else:
+                        new_package = package + '.' + name
+                    stack.append((fn, '', new_package, False))
+                else:
+                    stack.append((fn, prefix + name + '/', package, only_in_packages))
+            elif package or not only_in_packages:
+                # is a file
+                bad_name = False
+                for pattern in exclude:
+                    if (fnmatchcase(name, pattern)
+                        or fn.lower() == pattern.lower()):
+                        bad_name = True
+                        if show_ignored:
+                            print >> sys.stderr, (
+                                "File %s ignored by pattern %s"
+                                % (fn, pattern))
+                        break
+                if bad_name:
+                    continue
+                out.setdefault(package, []).append(prefix + name)
+    return out
 
 
 setup(
@@ -17,6 +107,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     packages=find_packages(),
+    package_data=find_package_data(exclude_directories=standard_exclude_directories),
     install_requires=[
         "gevent-socketio==0.3.5-beta",
         "irc==2.0",


### PR DESCRIPTION
I was checking out gnotty (great stuff so far!) and I was getting this error when running gnottify w/o arguments:

```
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/gevent/pywsgi.py", line 438, in handle_one_response
    self.run_application()
  File "build/bdist.linux-x86_64/egg/gevent/pywsgi.py", line 424, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/home/philip/projects/django/gnotty/env/lib/python2.6/site-packages/Gnotty-0.0.1-py2.6.egg/gnotty/server.py", line 164, in __call__
    response = dispatch(environ)
  File "/home/philip/projects/django/gnotty/env/lib/python2.6/site-packages/Gnotty-0.0.1-py2.6.egg/gnotty/server.py", line 99, in respond_static
    content = self.index()
  File "/home/philip/projects/django/gnotty/env/lib/python2.6/site-packages/Gnotty-0.0.1-py2.6.egg/gnotty/server.py", line 118, in index
    with open(os.path.join(template_dir, "base.html"), "r") as f:
IOError: [Errno 2] No such file or directory: '/home/philip/projects/django/gnotty/env/lib/python2.6/site-packages/Gnotty-0.0.1-py2.6.egg/gnotty/templates/gnotty/base.html'
<SocketIOServer fileno=7 address=127.0.0.1:8080>: Failed to handle request:
  request = GET / HTTP/1.1 from ('127.0.0.1', 40472)
  application = <gnotty.server.IRCApplication object at 0xe2fc50>
```

This pull request adds the missing directories to the installer.
