### PR TITLE
Add args to gnottify_runserver

### DIFF
--- a/gnotty/management/commands/gnottify_runserver.py
+++ b/gnotty/management/commands/gnottify_runserver.py
@@ -8,6 +8,5 @@ from gnotty.management.commands import gnottify
 class Command(gnottify.Command):
 
     def handle(self, *args, **options):
-        spawn(lambda: call_command("runserver"))
+        spawn(lambda: call_command("runserver", *args))
         super(Command, self).handle(*args, **options)
-


### PR DESCRIPTION
`python manage.py gnottify_runserver 8888` ignores the port  8888 part. This pull request fixes that.
