### PR TITLE
Updates url template tag to use new 1.5 format as it is now the current release.

### DIFF
--- a/gnotty/templates/gnotty/base.html
+++ b/gnotty/templates/gnotty/base.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% load gnotty_tags %}<!doctype html>
 <html lang="en">
 
@@ -27,7 +28,7 @@
 <div class="navbar navbar-fixed-top">
 <div class="navbar-inner">
 <div class="container">
-    <a class="brand" href="{% url gnotty_chat %}">{{ IRC_CHANNEL }}</a>
+    <a class="brand" href="{% url 'gnotty_chat' %}">{{ IRC_CHANNEL }}</a>
     {% gnotty_nav %}
     <form id="joins-leaves" class="pull-right nav-collapse" action="#joins-leaves">
         <input type="checkbox" id="show-joins-leaves">
@@ -42,7 +43,7 @@
 </div>
 
 <footer>
-<form class="container form-inline chat" action="{% url gnotty_chat %}">
+<form class="container form-inline chat" action="{% url 'gnotty_chat' %}">
 <div class="row">
 <div class="span9 control-group">
 <div class="controls">

--- a/gnotty/templates/gnotty/calendar.html
+++ b/gnotty/templates/gnotty/calendar.html
@@ -1,5 +1,8 @@
 {% extends "gnotty/base.html" %}
 
+{% load url from future %}
+
+
 {% block content %}
 {% for month in months %}
 
@@ -9,13 +12,13 @@
 
 <div class="span4">
 <table class="table table-striped calendar">
-    <tr><th colspan="7"><h2><a href="{% url gnotty_month month.month.year month.month.month %}">{{ month.month|date:"N Y" }}</a></h2></th></tr>
+    <tr><th colspan="7"><h2><a href="{% url 'gnotty_month' month.month.year month.month.month %}">{{ month.month|date:"N Y" }}</a></h2></th></tr>
     {% for week in month.weeks %}
     <tr>
     {% for day in week %}
     <td{% if not day.in_month %} class="not-in-month"{% endif %}>
         {% if day.has_messages %}
-        <a href="{% url gnotty_day day.date.year day.date.month day.date.day %}">{{ day.date.day }}</a>
+        <a href="{% url 'gnotty_day' day.date.year day.date.month day.date.day %}">{{ day.date.day }}</a>
         {% else %}
         {{ day.date.day }}
         {% endif %}

--- a/gnotty/templates/gnotty/includes/nav.html
+++ b/gnotty/templates/gnotty/includes/nav.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 
 <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
     <span class="icon-bar"></span>
@@ -7,7 +8,7 @@
 
 <div class="nav-collapse">
 
-    <form action="{% url gnotty_search %}" class="navbar-search pull-right">
+    <form action="{% url 'gnotty_search' %}" class="navbar-search pull-right">
         <input required placeholder="Search" type="text" name="q" value="{{ request.GET.q }}">
         {% if request.user.is_authenticated %}
         <a class="btn btn-small logout" href="{{ LOGOUT_URL }}">Logout</a>
@@ -20,7 +21,7 @@
             <a href="#" data-toggle="dropdown">Archives<span class="caret"></span></a>
             <ul class="dropdown-menu">
                 {% for year in years %}
-                <li><a href="{% url gnotty_year year %}">{{ year }}</a></li>
+                <li><a href="{% url 'gnotty_year' year %}">{{ year }}</a></li>
                 {% endfor %}
             </ul>
         </li>

--- a/gnotty/templates/gnotty/messages.html
+++ b/gnotty/templates/gnotty/messages.html
@@ -1,5 +1,8 @@
 {% extends "gnotty/base.html" %}
 
+{% load url from future %}
+
+
 {% block extrahead %}
 {{ block.super }}
 {% if request.GET.id %}
@@ -31,7 +34,7 @@ if (!location.hash) {
             {% if prev_url %}<li><a href="{{ prev_url }}" class="previous">&larr; Previous day</a></li>{% endif %}
             {% if next_url %}<li><a href="{{ next_url }}" class="next">Next day &rarr;</a></li>{% endif %}
         </ul>
-        <h2><a href="{% url gnotty_day day.year day.month day.day %}">{{ day }}</a></h2>
+        <h2><a href="{% url 'gnotty_day' day.year day.month day.day %}">{{ day }}</a></h2>
     </th>
 </tr>
 {% endifchanged %}


### PR DESCRIPTION
Hey,

I used django-future-url to update the url template tag to the new format with sensible fallback for 1.4 (using the future package). Good work on the project, I have spotted one other deprecation warning to do with the crypto library, I will take a look at it.

All the best,

Chris 
