### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/gnotty/server.py
+++ b/gnotty/server.py
@@ -4,7 +4,7 @@ from __future__ import with_statement
 from gevent import monkey, spawn, sleep
 monkey.patch_all()
 
-from Cookie import Cookie
+from Cookie import SimpleCookie
 from cgi import FieldStorage
 from logging import getLogger, StreamHandler
 from mimetypes import guess_type
@@ -196,7 +196,7 @@ class IRCApplication(object):
                 from django.contrib.auth.models import User
                 from django.contrib.sessions.models import Session
                 from django.core.exceptions import ObjectDoesNotExist
-                cookie = Cookie(environ["HTTP_COOKIE"])
+                cookie = SimpleCookie(environ["HTTP_COOKIE"])
                 cookie_name = django_settings.SESSION_COOKIE_NAME
                 session_key = cookie[cookie_name].value
                 session = Session.objects.get(session_key=session_key)


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
Cookie.Cookie maps to Cookie.SmartCookie.
For example, the following cookie header would shutdown your server:
Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
